### PR TITLE
fix: add maximum cap for insurance fee rate

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -415,7 +415,7 @@ func New(l Logger, baseDir string, cfg Config) (*Network, error) {
 			CodeHash:    common.BytesToHash(evmtypes.EmptyCodeHash).Hex(),
 		})
 
-		commission, err := sdk.NewDecFromStr("0.5")
+		commission, err := sdk.NewDecFromStr("0.1")
 		if err != nil {
 			return nil, err
 		}

--- a/x/liquidstaking/keeper/liquidstaking.go
+++ b/x/liquidstaking/keeper/liquidstaking.go
@@ -816,6 +816,11 @@ func (k Keeper) DoProvideInsurance(ctx sdk.Context, msg *types.MsgProvideInsuran
 		return
 	}
 
+	if feeRate.Add(validator.GetCommission()).GTE(types.MaximumInsValFeeRate) {
+		err = sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "fee rate(validator fee rate + insurance fee rate) must be less than %s", types.MaximumInsValFeeRate.String())
+		return
+	}
+
 	// Create an insurnace
 	insId := k.getNextInsuranceIdWithUpdate(ctx)
 	ins = types.NewInsurance(insId, providerAddr.String(), valAddr.String(), feeRate)

--- a/x/liquidstaking/keeper/liquidstaking_test.go
+++ b/x/liquidstaking/keeper/liquidstaking_test.go
@@ -165,7 +165,7 @@ func (suite *KeeperTestSuite) TestProvideInsurance() {
 			"amount must be greater than minimum collateral",
 		},
 		{
-			"fee rate >= minimum fee rate",
+			"fee rate >= maximum fee rate",
 			&types.MsgProvideInsurance{
 				ProviderAddress:  providers[0].String(),
 				ValidatorAddress: valAddrs[0].String(),

--- a/x/liquidstaking/keeper/liquidstaking_test.go
+++ b/x/liquidstaking/keeper/liquidstaking_test.go
@@ -164,6 +164,17 @@ func (suite *KeeperTestSuite) TestProvideInsurance() {
 			nil,
 			"amount must be greater than minimum collateral",
 		},
+		{
+			"fee rate >= minimum fee rate",
+			&types.MsgProvideInsurance{
+				ProviderAddress:  providers[0].String(),
+				ValidatorAddress: valAddrs[0].String(),
+				Amount:           oneInsurance,
+				FeeRate:          TenPercentFeeRate.MulInt(sdk.NewInt(4)), // vFee 10% + 40% = 50%
+			},
+			nil,
+			"fee rate(validator fee rate + insurance fee rate) must be less than 0.500000000000000000",
+		},
 	} {
 		suite.Run(tc.name, func() {
 			s.Require().NoError(tc.msg.ValidateBasic())

--- a/x/liquidstaking/spec/04_messages.md
+++ b/x/liquidstaking/spec/04_messages.md
@@ -46,7 +46,8 @@ type MsgLiquidUnstake struct {
 
 Provide insurance to cover slashing penalties for chunks and to receive commission. 
 * 9% of chunk size tokens is recommended for the `msg.Amount`.
-* 7% is minimum collateral for the chunk size tokens.
+* 7% is minimum collateral for the chunk size tokens. If the collateral is less than 7%, the insurance will be unpaired and the provider will not receive commission.
+* The fee rate + Validator(msg.ValidatorAddress)'s fee rate must be less than 50%.
 
 ```go
 type MsgProvideInsurance struct {
@@ -62,6 +63,7 @@ type MsgProvideInsurance struct {
 - `msg.Amount` is not bond denom
 - `msg.Amount` must be bigger than minimum collateral (7% of chunk size tokens)
 - `msg.ValidatorAddress` is not valid validator
+- `msg.FeeRate` + Validator(msg.ValidatorAddress).Commission.Rate >= 0.5 (50%)
 
 ### MsgCancelProvideInsurance
 

--- a/x/liquidstaking/types/liquidstaking.go
+++ b/x/liquidstaking/types/liquidstaking.go
@@ -11,6 +11,9 @@ const Empty uint64 = 0
 var SecurityCap = sdk.MustNewDecFromStr("0.25")
 var MaximumDiscountRate = sdk.MustNewDecFromStr("0.03")
 
+// MaximumInsuranceFeeRate is a maximum cap of insurance + validator fee rate.
+var MaximumInsValFeeRate = sdk.MustNewDecFromStr("0.5")
+
 var DefaultLiquidBondDenom = "lscanto"
 var RewardPool = DeriveAddress(ModuleName, "RewardPool")
 var LsTokenEscrowAcc = DeriveAddress(ModuleName, "LsTokenEscrowAcc")


### PR DESCRIPTION
## Description

insurance fee rate + validator's fee rate must be smaller than 50%.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
