### PR TITLE
feat: add ValCommissionChangeLimitDecorator

### DIFF
--- a/app/ante/val_commission_change_ante.go
+++ b/app/ante/val_commission_change_ante.go
@@ -1,0 +1,112 @@
+package ante
+
+import (
+	"fmt"
+	"github.com/Canto-Network/Canto/v7/types"
+	liquidstakingkeeper "github.com/Canto-Network/Canto/v7/x/liquidstaking/keeper"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"time"
+
+	authzante "github.com/Canto-Network/Canto/v7/app/ante/cosmos"
+)
+
+// ValCommissionChangeLimitDecorator checks that if MsgEditValidator tries to change the commission rate.
+// If so, it allows msg only within 23 hours and 50 minutes of the next epoch.
+// Because liquidstaking module rank insurances based on insurance fee rate + validator's commission rate at every Epoch and
+// validators can change their commission rate by MsgEditValidator at any time, we need to limit the commission rate change.
+// If not, validator can change their commission rate as high to get more delegation rewards while epoch duration and as low right before the epoch, so it can still be ranked in.
+type ValCommissionChangeLimitDecorator struct {
+	liquidstakingKeeper *liquidstakingkeeper.Keeper
+	stakingKeeper       *stakingkeeper.Keeper
+	cdc                 codec.BinaryCodec
+}
+
+// NewValCommissionChangeLimitDecorator creates a new ValCommissionChangeLimitDecorator
+func NewValCommissionChangeLimitDecorator(
+	liquidstakingKeeper *liquidstakingkeeper.Keeper,
+	stakingKeeper *stakingkeeper.Keeper,
+	cdc codec.BinaryCodec,
+) ValCommissionChangeLimitDecorator {
+	return ValCommissionChangeLimitDecorator{
+		liquidstakingKeeper: liquidstakingKeeper,
+		stakingKeeper:       stakingKeeper,
+		cdc:                 cdc,
+	}
+}
+
+func (vccld ValCommissionChangeLimitDecorator) AnteHandle(
+	ctx sdk.Context,
+	tx sdk.Tx,
+	simulate bool,
+	next sdk.AnteHandler,
+) (newCtx sdk.Context, err error) {
+	msgs := tx.GetMsgs()
+	if err = vccld.ValidateMsgs(ctx, msgs); err != nil {
+		return ctx, err
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func (vccld ValCommissionChangeLimitDecorator) ValidateMsgs(ctx sdk.Context, msgs []sdk.Msg) error {
+	var validMsg func(m sdk.Msg, nestedCnt int) error
+	validMsg = func(m sdk.Msg, nestedCnt int) error {
+		if nestedCnt >= authzante.MaxNestedMsgs {
+			return fmt.Errorf("found more nested msgs than permited. Limit is : %d", authzante.MaxNestedMsgs)
+		}
+		switch msg := m.(type) {
+		case *authz.MsgExec:
+			for _, v := range msg.Msgs {
+				var innerMsg sdk.Msg
+				if err := vccld.cdc.UnpackAny(v, &innerMsg); err != nil {
+					return sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "cannot unmarshal authz exec msgs")
+				}
+				nestedCnt++
+				if err := validMsg(innerMsg, nestedCnt); err != nil {
+					return err
+				}
+			}
+
+		case *stakingtypes.MsgEditValidator:
+			valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddress)
+			if err != nil {
+				return err
+			}
+			val, found := vccld.stakingKeeper.GetValidator(ctx, valAddr)
+			if !found {
+				return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "validator does not exist")
+			}
+			if val.Commission.Rate.Equal(*msg.CommissionRate) {
+				// This is not a commission rate change.
+				return nil
+			}
+			// Check if the commission rate change is within 23 hours and 50 minutes of the epoch.
+			epoch := vccld.liquidstakingKeeper.GetEpoch(ctx)
+			nextEpochTime := epoch.StartTime.Add(epoch.Duration)
+			timeLimit := nextEpochTime.Add(-23 * time.Hour).Add(-50 * time.Minute)
+			if ctx.BlockTime().After(timeLimit) {
+				return nil
+			}
+			timeLeft := timeLimit.Sub(ctx.BlockTime())
+			return sdkerrors.Wrap(
+				types.ErrChangingValCommissionForbidden,
+				fmt.Sprintf("%s left", timeLeft.String()),
+			)
+		default:
+			return nil
+		}
+		return nil
+	}
+
+	for _, m := range msgs {
+		if err := validMsg(m, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/app/ante/val_commission_change_ante_test.go
+++ b/app/ante/val_commission_change_ante_test.go
@@ -1,0 +1,360 @@
+package ante_test
+
+import (
+	"fmt"
+	"github.com/Canto-Network/Canto/v7/app/ante"
+	authzante "github.com/Canto-Network/Canto/v7/app/ante/cosmos"
+	"github.com/Canto-Network/Canto/v7/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"time"
+)
+
+func (suite *AnteTestSuite) TestValCommissionChange() {
+	suite.SetupTest(false)
+	epoch := suite.app.LiquidStakingKeeper.GetEpoch(suite.ctx)
+	validators := suite.app.StakingKeeper.GetAllValidators(suite.ctx)
+
+	tests := []struct {
+		desc          string
+		setEpoch      func(ctx sdk.Context)
+		createMsg     func() *stakingtypes.MsgEditValidator
+		expectedError string
+	}{
+		{
+			"Pass: No fee rate change",
+			nil,
+			func() *stakingtypes.MsgEditValidator {
+				minSelfDelegation := validators[0].GetMinSelfDelegation()
+				feeRate := validators[0].GetCommission()
+				return stakingtypes.NewMsgEditValidator(
+					validators[0].GetOperator(), stakingtypes.Description{}, &feeRate, &minSelfDelegation,
+				)
+			},
+			"",
+		},
+		{
+			"Pass: 23 hours and 49 minutes left to the next epoch",
+			func(ctx sdk.Context) {
+				// 23 hours and 49 minutes left to the next epoch
+				nextEpochTime := ctx.BlockTime().Add(23*time.Hour + 49*time.Minute)
+				epoch.StartTime = nextEpochTime.Add(-epoch.Duration)
+				suite.app.LiquidStakingKeeper.SetEpoch(suite.ctx, epoch)
+			},
+			func() *stakingtypes.MsgEditValidator {
+				minSelfDelegation := validators[0].GetMinSelfDelegation()
+				feeRateChanged := validators[0].GetCommission().Add(sdk.NewDecWithPrec(1, 2))
+				return stakingtypes.NewMsgEditValidator(
+					validators[0].GetOperator(), stakingtypes.Description{}, &feeRateChanged, &minSelfDelegation,
+				)
+			},
+			"",
+		},
+		{
+			"Pass: 1 hour left to the next epoch",
+			func(ctx sdk.Context) {
+				// 23 hours and 49 minutes left to the next epoch
+				nextEpochTime := ctx.BlockTime().Add(time.Hour)
+				epoch.StartTime = nextEpochTime.Add(-epoch.Duration)
+				suite.app.LiquidStakingKeeper.SetEpoch(suite.ctx, epoch)
+			},
+			func() *stakingtypes.MsgEditValidator {
+				minSelfDelegation := validators[0].GetMinSelfDelegation()
+				feeRateChanged := validators[0].GetCommission().Add(sdk.NewDecWithPrec(1, 2))
+				return stakingtypes.NewMsgEditValidator(
+					validators[0].GetOperator(), stakingtypes.Description{}, &feeRateChanged, &minSelfDelegation,
+				)
+			},
+			"",
+		},
+		{
+			"Fail: 23 hours and 51 minutes left to the next epoch (1 minute over)",
+			func(ctx sdk.Context) {
+				// 23 hours and 51 minutes left to the next epoch
+				nextEpochTime := ctx.BlockTime().Add(23*time.Hour + 51*time.Minute)
+				epoch.StartTime = nextEpochTime.Add(-epoch.Duration)
+				suite.app.LiquidStakingKeeper.SetEpoch(suite.ctx, epoch)
+			},
+			func() *stakingtypes.MsgEditValidator {
+				minSelfDelegation := validators[0].GetMinSelfDelegation()
+				feeRateChanged := validators[0].GetCommission().Add(sdk.NewDecWithPrec(1, 2))
+				return stakingtypes.NewMsgEditValidator(
+					validators[0].GetOperator(), stakingtypes.Description{}, &feeRateChanged, &minSelfDelegation,
+				)
+			},
+			"1m0s left",
+		},
+		{
+			"Fail: 3 days left to the next epoch",
+			func(ctx sdk.Context) {
+				// 23 hours and 51 minutes left to the next epoch
+				nextEpochTime := ctx.BlockTime().Add(3 * 24 * time.Hour)
+				epoch.StartTime = nextEpochTime.Add(-epoch.Duration)
+				suite.app.LiquidStakingKeeper.SetEpoch(suite.ctx, epoch)
+			},
+			func() *stakingtypes.MsgEditValidator {
+				minSelfDelegation := validators[0].GetMinSelfDelegation()
+				feeRateChanged := validators[0].GetCommission().Add(sdk.NewDecWithPrec(1, 2))
+				return stakingtypes.NewMsgEditValidator(
+					validators[0].GetOperator(), stakingtypes.Description{}, &feeRateChanged, &minSelfDelegation,
+				)
+			},
+			"48h10m0s left",
+		},
+	}
+
+	vccld := ante.NewValCommissionChangeLimitDecorator(&suite.app.LiquidStakingKeeper, &suite.app.StakingKeeper, suite.app.AppCodec())
+	anteHandler := sdk.ChainAnteDecorators(vccld)
+	for _, tc := range tests {
+		suite.Run(tc.desc, func() {
+			if tc.setEpoch != nil {
+				tc.setEpoch(suite.ctx)
+			}
+			tx, err := createTx(suite.priv, []sdk.Msg{tc.createMsg()}...)
+			suite.Require().NoError(err)
+			_, err = anteHandler(suite.ctx, tx, false)
+			if tc.expectedError != "" {
+				suite.ErrorIs(err, types.ErrChangingValCommissionForbidden)
+				suite.ErrorContains(err, tc.expectedError)
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
+// authz, nested, multi msg cases
+func (suite *AnteTestSuite) TestValCommissionChangeAuthzCases() {
+	suite.SetupTest(false)
+
+	validators := suite.app.StakingKeeper.GetAllValidators(suite.ctx)
+	minSelfDelegation := validators[0].GetMinSelfDelegation()
+	feeRate := validators[0].GetCommission()
+	notLimitedMsgNoFeeRateChange := stakingtypes.NewMsgEditValidator(
+		validators[0].GetOperator(), stakingtypes.Description{}, &feeRate, &minSelfDelegation,
+	)
+	feeRateChanged := feeRate.Add(sdk.NewDecWithPrec(1, 2))
+	limitedMsgFeeRateChange := stakingtypes.NewMsgEditValidator(
+		validators[0].GetOperator(), stakingtypes.Description{}, &feeRateChanged, &minSelfDelegation,
+	)
+
+	coins := sdk.NewCoins(sdk.NewCoin(suite.app.StakingKeeper.BondDenom(suite.ctx), sdk.NewInt(10000)))
+	normMsg := &banktypes.MsgSend{
+		FromAddress: suite.addr.String(),
+		ToAddress:   suite.addr.String(),
+		Amount:      coins,
+	}
+
+	wrapAuthzMsg := func(msg sdk.Msg) *authz.MsgExec {
+		v := authz.NewMsgExec(suite.addr, []sdk.Msg{msg})
+		return &v
+	}
+	authzMsgNoFeeRateChange := authz.NewMsgExec(suite.addr, []sdk.Msg{notLimitedMsgNoFeeRateChange})
+	authzMsgFeeRateChange := authz.NewMsgExec(suite.addr, []sdk.Msg{limitedMsgFeeRateChange})
+	authzMultiMsgNoFeeRateChange := authz.NewMsgExec(suite.addr, []sdk.Msg{normMsg, notLimitedMsgNoFeeRateChange})
+	authzMultiMsgFeeRateChange := authz.NewMsgExec(suite.addr, []sdk.Msg{normMsg, limitedMsgFeeRateChange})
+
+	// set epoch time to 2 days before the next epoch which means
+	// fee rate change msg cannot pass time limit validation
+	epoch := suite.app.LiquidStakingKeeper.GetEpoch(suite.ctx)
+	nextEpochTime := suite.ctx.BlockTime().Add(2 * 24 * time.Hour)
+	epoch.StartTime = nextEpochTime.Add(-epoch.Duration)
+	suite.app.LiquidStakingKeeper.SetEpoch(suite.ctx, epoch)
+
+	tests := []struct {
+		desc          string
+		msgs          []sdk.Msg
+		expectedError error
+	}{
+		{
+			"normal msg",
+			[]sdk.Msg{normMsg},
+			nil,
+		},
+		{
+			"pass: no fee rate change msg",
+			[]sdk.Msg{notLimitedMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: limited msg",
+			[]sdk.Msg{limitedMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: multi msg",
+			[]sdk.Msg{normMsg, notLimitedMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: multi msg including limited msg",
+			[]sdk.Msg{normMsg, limitedMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: multi msg 2",
+			[]sdk.Msg{notLimitedMsgNoFeeRateChange, normMsg},
+			nil,
+		},
+		{
+			"fail: multi msg including limited msg 2",
+			[]sdk.Msg{limitedMsgFeeRateChange, normMsg},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: authz msg",
+			[]sdk.Msg{&authzMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: authz msg including limited msg",
+			[]sdk.Msg{&authzMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: authz msg 2",
+			[]sdk.Msg{normMsg, &authzMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: authz msg including limited msg 2",
+			[]sdk.Msg{normMsg, &authzMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: authz msg 3",
+			[]sdk.Msg{&authzMsgNoFeeRateChange, normMsg},
+			nil,
+		},
+		{
+			"fail: authz msg including limited msg 3",
+			[]sdk.Msg{&authzMsgFeeRateChange, normMsg},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: authz msg 4",
+			[]sdk.Msg{&authzMultiMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: authz msg including limited msg 4",
+			[]sdk.Msg{&authzMultiMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: authz msg 5",
+			[]sdk.Msg{normMsg, &authzMultiMsgNoFeeRateChange},
+			nil,
+		},
+		{
+			"fail: authz msg including limited msg 5",
+			[]sdk.Msg{normMsg, &authzMultiMsgFeeRateChange},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"fail: nested authz msg-1",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						&authzMsgFeeRateChange),
+				),
+			},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"fail: nested authz msg-2",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						wrapAuthzMsg(
+							wrapAuthzMsg(
+								&authzMsgFeeRateChange),
+						),
+					),
+				),
+			},
+			types.ErrChangingValCommissionForbidden,
+		},
+		{
+			"pass: nested authz msg",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						wrapAuthzMsg(
+							wrapAuthzMsg(
+								normMsg),
+						),
+					),
+				),
+			},
+			nil,
+		},
+		{
+			"pass: nested authz msg 2",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						wrapAuthzMsg(
+							wrapAuthzMsg(
+								&authzMsgNoFeeRateChange),
+						),
+					),
+				),
+			},
+			nil,
+		},
+		{
+			"fail: nested authz msg exceeding limit",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						wrapAuthzMsg(
+							wrapAuthzMsg(
+								wrapAuthzMsg(
+									wrapAuthzMsg(
+										&authzMsgFeeRateChange),
+								),
+							),
+						),
+					),
+				),
+			},
+			fmt.Errorf("found more nested msgs than permited. Limit is : %d", authzante.MaxNestedMsgs),
+		},
+		{
+			"fail: nested authz msg exceeding limit 2",
+			[]sdk.Msg{
+				wrapAuthzMsg(
+					wrapAuthzMsg(
+						wrapAuthzMsg(
+							wrapAuthzMsg(
+								wrapAuthzMsg(
+									wrapAuthzMsg(
+										normMsg),
+								),
+							),
+						),
+					),
+				),
+			},
+			fmt.Errorf("found more nested msgs than permited. Limit is : %d", authzante.MaxNestedMsgs),
+		},
+	}
+
+	vcd := ante.NewValCommissionChangeLimitDecorator(&suite.app.LiquidStakingKeeper, &suite.app.StakingKeeper, suite.app.AppCodec())
+	anteHandler := sdk.ChainAnteDecorators(vcd)
+	for _, tc := range tests {
+		suite.Run(tc.desc, func() {
+			tx, err := createTx(suite.priv, tc.msgs...)
+			suite.Require().NoError(err)
+			_, err = anteHandler(suite.ctx, tx, false)
+			if tc.expectedError != nil {
+				suite.ErrorContains(err, tc.expectedError.Error())
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}

--- a/app/app.go
+++ b/app/app.go
@@ -806,18 +806,20 @@ func NewCanto(
 
 	maxGasWanted := cast.ToUint64(appOpts.Get(srvflags.EVMMaxTxGasWanted))
 	options := ante.HandlerOptions{
-		AccountKeeper:   app.AccountKeeper,
-		BankKeeper:      app.BankKeeper,
-		EvmKeeper:       app.EvmKeeper,
-		SlashingKeeper:  &app.SlashingKeeper,
-		FeegrantKeeper:  app.FeeGrantKeeper,
-		IBCKeeper:       app.IBCKeeper,
-		FeeMarketKeeper: app.FeeMarketKeeper,
-		SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
-		SigGasConsumer:  SigVerificationGasConsumer,
-		Cdc:             appCodec,
-		MaxTxGasWanted:  maxGasWanted,
-		Simulation:      simulation,
+		AccountKeeper:       app.AccountKeeper,
+		BankKeeper:          app.BankKeeper,
+		EvmKeeper:           app.EvmKeeper,
+		StakingKeeper:       &app.StakingKeeper,
+		SlashingKeeper:      &app.SlashingKeeper,
+		FeegrantKeeper:      app.FeeGrantKeeper,
+		IBCKeeper:           app.IBCKeeper,
+		FeeMarketKeeper:     app.FeeMarketKeeper,
+		LiquidStakingKeeper: &app.LiquidStakingKeeper,
+		SignModeHandler:     encodingConfig.TxConfig.SignModeHandler(),
+		SigGasConsumer:      SigVerificationGasConsumer,
+		Cdc:                 appCodec,
+		MaxTxGasWanted:      maxGasWanted,
+		Simulation:          simulation,
 	}
 
 	if err := options.Validate(); err != nil {

--- a/types/errors.go
+++ b/types/errors.go
@@ -17,6 +17,7 @@ const (
 	codeInvalidSlashFractionDowntime
 	codeChangingUnbondingPeriodForbidden
 	codeChangingBondDenomForbidden
+	codeChangingValCommissionForbidden
 )
 
 // errors
@@ -29,4 +30,5 @@ var (
 	ErrInvalidSlashFractionDowntime     = sdkerrors.Register(RootCodespace, codeInvalidSlashFractionDowntime, "cannot increase slash fraction downtime")
 	ErrChangingUnbondingPeriodForbidden = sdkerrors.Register(RootCodespace, codeChangingUnbondingPeriodForbidden, "changing unbonding period not allowed")
 	ErrChangingBondDenomForbidden       = sdkerrors.Register(RootCodespace, codeChangingBondDenomForbidden, "changing bond denom not allowed")
+	ErrChangingValCommissionForbidden   = sdkerrors.Register(RootCodespace, codeChangingValCommissionForbidden, "commission rate change is only allowed within 23 hours and 50 minutes of the epoch")
 )

--- a/x/liquidstaking/spec/02_state.md
+++ b/x/liquidstaking/spec/02_state.md
@@ -24,7 +24,7 @@ the commission fee rate set by the validator designated by the insurance provide
 3. `Unpairing`: A paired chunk enters this status when paired insurance is started to be withdrawn or 
 it's balance <= 5.75%(double_sign_fraction + down_time_fraction) or the validator becomes invalid(e.g. tombstoned).
   * 5.75%(double_sign_fraction + down_time_fraction) is guaranteed when slashing param change is limited through antehandler. we already have this mechanism. 
-please check **[Param Change Ante Handlers](10_param_change_ante_handlers.md#param-change-ante-handlers).** for detail.
+please check **[Param Change Ante Handlers](10_ante_handlers.md#param-change-ante-handlers).** for detail.
 4. `UnpairingForUnstaking`: When a delegator (also known as a liquid staker) sends a `MsgLiquidUnstake`, it is queued as a `UnpairingForUnstakingChunkInfo`. 
 At the end of the epoch, the actual undelegation is triggered and the chunk enters this state. 
 Once the unbonding period is over in next epoch, the tokens corresponding chunk size are returned to the delegator's account and the associated chunk object is removed.

--- a/x/liquidstaking/spec/10_ante_handlers.md
+++ b/x/liquidstaking/spec/10_ante_handlers.md
@@ -30,3 +30,15 @@ If not, the paired chunk start to be unbonded. 5.75% is calculated based on the 
 
 ### Staking module
 * UnbondingTime or BondDenom are not allowed to change.
+
+# Validation Commission Change Ante Handler
+
+The liquidstaking module has fee rate competition mechanism, so validator have incentive to lower their commission rate to get delegations from liquid staking module.
+At every epoch, the liquidstaking module will check the validator commission rate + insurance fee rate and sorts by ascending order(insurance with lower fee rate comes first).
+
+But validator can edit its commission rate at any time by using MsgEditValidator which can make the fee rate competition mechanism meaningless.
+To avoid this, we need to impose restrictions on validator commission changes.
+
+## ValCommissionChangeLimitDecorator
+It only accepts MsgEditValidator when current block time is within 23 hours and 50 minutes of the next epoch. 
+staking module have 24 hours limit for continuous MsgEditValidator, so validator can change only one time in that period.


### PR DESCRIPTION
## Description

* Closes #37 
* ValCommissionChangeLimitDecorator limits MsgEditValidator which change commission rates.
  * msg only can be accepted within 23 hours and 50 minutes of next epoch time.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
