### PR TITLE
fix: un-used variables and add sanity checks

### DIFF
--- a/x/liquidstaking/keeper/liquidstaking.go
+++ b/x/liquidstaking/keeper/liquidstaking.go
@@ -935,6 +935,11 @@ func (k Keeper) DoClaimDiscountedReward(ctx sdk.Context, msg *types.MsgClaimDisc
 	claimableCoin = k.bankKeeper.GetBalance(ctx, types.RewardPool, k.stakingKeeper.BondDenom(ctx))
 	burnAmt = msg.Amount
 
+	// sanity check to avoid division by zero
+	if discountedMintRate.IsZero() {
+		err = sdkerrors.Wrapf(types.ErrInvalidAmount, "discounted mint rate must be greater than zero")
+		return
+	}
 	// claim amount = (ls token amount / discounted mint rate)
 	claimAmt := burnAmt.Amount.ToDec().QuoTruncate(discountedMintRate).TruncateInt()
 	// Requester can claim only up to claimable amount

--- a/x/liquidstaking/keeper/liquidstaking.go
+++ b/x/liquidstaking/keeper/liquidstaking.go
@@ -932,7 +932,9 @@ func (k Keeper) DoClaimDiscountedReward(ctx sdk.Context, msg *types.MsgClaimDisc
 	var claimableCoin sdk.Coin
 	var burnAmt sdk.Coin
 
-	claimableCoin = k.bankKeeper.GetBalance(ctx, types.RewardPool, k.stakingKeeper.BondDenom(ctx))
+	rewardPoolCoins := k.bankKeeper.SpendableCoins(ctx, types.RewardPool)
+	bondDenom := k.stakingKeeper.BondDenom(ctx)
+	claimableCoin = sdk.NewCoin(bondDenom, rewardPoolCoins.AmountOf(bondDenom))
 	burnAmt = msg.Amount
 
 	// sanity check to avoid division by zero

--- a/x/liquidstaking/keeper/msg_server.go
+++ b/x/liquidstaking/keeper/msg_server.go
@@ -14,7 +14,7 @@ var _ types.MsgServer = &Keeper{}
 func (k Keeper) LiquidStake(goCtx context.Context, msg *types.MsgLiquidStake) (*types.MsgLiquidStakeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	chunks, newShares, lsTokenMintAmount, err := k.DoLiquidStake(ctx, msg)
+	chunks, totalNewShares, totalLsTokenMintAmount, err := k.DoLiquidStake(ctx, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -33,10 +33,10 @@ func (k Keeper) LiquidStake(goCtx context.Context, msg *types.MsgLiquidStake) (*
 			sdk.NewAttribute(types.AttributeKeyChunkIds, strings.Join(chunkIds, ", ")),
 			sdk.NewAttribute(types.AttributeKeyDelegator, msg.DelegatorAddress),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
-			sdk.NewAttribute(types.AttributeKeyNewShares, newShares.String()),
+			sdk.NewAttribute(types.AttributeKeyNewShares, totalNewShares.String()),
 			sdk.NewAttribute(
 				types.AttributeKeyLsTokenMintedAmount,
-				sdk.Coin{Denom: types.DefaultLiquidBondDenom, Amount: lsTokenMintAmount}.String(),
+				sdk.Coin{Denom: types.DefaultLiquidBondDenom, Amount: totalLsTokenMintAmount}.String(),
 			),
 		),
 	})

--- a/x/liquidstaking/types/net_amount_essentials.go
+++ b/x/liquidstaking/types/net_amount_essentials.go
@@ -23,7 +23,7 @@ func (nase NetAmountStateEssentials) CalcMintRate() sdk.Dec {
 // CalcDiscountRate calculates the current discount rate.
 // reward module account's balance / (num paired chunks * chunk size)
 func (nase NetAmountStateEssentials) CalcDiscountRate(maximumDiscountRate sdk.Dec) sdk.Dec {
-	if nase.RewardModuleAccBalance.IsZero() || maximumDiscountRate.IsZero() {
+	if nase.RewardModuleAccBalance.IsZero() || maximumDiscountRate.IsZero() || !nase.NetAmount.IsPositive() {
 		return sdk.ZeroDec()
 	}
 	discountRate := nase.RewardModuleAccBalance.ToDec().QuoTruncate(nase.NetAmount)


### PR DESCRIPTION
## Description

applied feedbacks from @jeonghoyeo7 's code-reveiw 

* `DoLiquidStake` must returns total new shares and total ls token mint amount because user can liquid stake multiple chunks.
* add sanity checks
  * use sdk.Int instead of int64 when calc `chunksToLiquidUnstake` to avoid un-expected overflow error. 
  * avoid division by zero

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
