### PR TITLE
refactor: Remove deprecated sdk.WrapSDKContext

### DIFF
--- a/x/coinswap/keeper/grpc_query_test.go
+++ b/x/coinswap/keeper/grpc_query_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *TestSuite) TestGRPCParams() {
-	resp, err := s.queryClient.Params(sdk.WrapSDKContext(s.ctx), &types.QueryParamsRequest{})
+	resp, err := s.queryClient.Params(s.ctx, &types.QueryParamsRequest{})
 	s.Require().NoError(err)
 	s.Require().Equal(s.keeper.GetParams(s.ctx), resp.Params)
 }
@@ -17,7 +17,7 @@ func (s *TestSuite) TestGRPCPool() {
 	poolId := types.GetPoolId(denomBTC)
 	pool, _ := s.app.CoinswapKeeper.GetPool(s.ctx, poolId)
 
-	resp, err := s.queryClient.LiquidityPool(sdk.WrapSDKContext(s.ctx), &types.QueryLiquidityPoolRequest{LptDenom: pool.LptDenom})
+	resp, err := s.queryClient.LiquidityPool(s.ctx, &types.QueryLiquidityPoolRequest{LptDenom: pool.LptDenom})
 	s.Require().NoError(err)
 	s.Require().Equal(pool.Id, resp.Pool.Id)
 	s.Require().Equal(pool.EscrowAddress, resp.Pool.EscrowAddress)
@@ -36,12 +36,12 @@ func (s *TestSuite) TestGRPCPool() {
 
 func (s *TestSuite) TestGRPCPools() {
 	_, _ = createReservePool(s, denomBTC)
-	resp, err := s.queryClient.LiquidityPools(sdk.WrapSDKContext(s.ctx), &types.QueryLiquidityPoolsRequest{})
+	resp, err := s.queryClient.LiquidityPools(s.ctx, &types.QueryLiquidityPoolsRequest{})
 	s.Require().NoError(err)
 	s.Require().Len(resp.Pools, 1)
 
 	_, _ = createReservePool(s, denomETH)
-	resp, err = s.queryClient.LiquidityPools(sdk.WrapSDKContext(s.ctx), &types.QueryLiquidityPoolsRequest{})
+	resp, err = s.queryClient.LiquidityPools(s.ctx, &types.QueryLiquidityPoolsRequest{})
 	s.Require().NoError(err)
 	s.Require().Len(resp.Pools, 2)
 }

--- a/x/csr/keeper/grpc_query_test.go
+++ b/x/csr/keeper/grpc_query_test.go
@@ -2,7 +2,6 @@ package keeper_test
 
 import (
 	"github.com/Canto-Network/Canto/v7/x/csr/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/evmos/ethermint/tests"
 )
@@ -10,8 +9,7 @@ import (
 // Special edge case for when the request made is null, cannot be routed to the query client
 func (suite *KeeperTestSuite) TestKeeperCSRs() {
 	suite.SetupTest()
-	ctx := sdk.WrapSDKContext(suite.ctx)
-	res, err := suite.app.CSRKeeper.CSRs(ctx, nil)
+	res, err := suite.app.CSRKeeper.CSRs(suite.ctx, nil)
 	suite.Require().Error(err)
 	suite.Require().Nil(res)
 }
@@ -114,10 +112,9 @@ func (suite *KeeperTestSuite) TestCSRs() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.prepare()
 
-			response, err := suite.queryClient.CSRs(ctx, request)
+			response, err := suite.queryClient.CSRs(suite.ctx, request)
 			if tc.pass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expectedResponse.Pagination.Total, response.Pagination.Total)
@@ -132,8 +129,7 @@ func (suite *KeeperTestSuite) TestCSRs() {
 // Special edge case for when the request made is null, cannot be routed to the query client
 func (suite *KeeperTestSuite) TestKeeperCSRsByNFT() {
 	suite.SetupTest()
-	ctx := sdk.WrapSDKContext(suite.ctx)
-	res, err := suite.app.CSRKeeper.CSRByNFT(ctx, nil)
+	res, err := suite.app.CSRKeeper.CSRByNFT(suite.ctx, nil)
 	suite.Require().Error(err)
 	suite.Require().Nil(res)
 }
@@ -190,10 +186,9 @@ func (suite *KeeperTestSuite) TestCSRByNFT() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.prepare()
 
-			response, err := suite.queryClient.CSRByNFT(ctx, request)
+			response, err := suite.queryClient.CSRByNFT(suite.ctx, request)
 			if tc.pass {
 				suite.Require().NoError(err)
 			} else {
@@ -207,8 +202,7 @@ func (suite *KeeperTestSuite) TestCSRByNFT() {
 // Special edge case for when the request made is null, cannot be routed to the query client
 func (suite *KeeperTestSuite) TestKeeperCSRsByContract() {
 	suite.SetupTest()
-	ctx := sdk.WrapSDKContext(suite.ctx)
-	res, err := suite.app.CSRKeeper.CSRByContract(ctx, nil)
+	res, err := suite.app.CSRKeeper.CSRByContract(suite.ctx, nil)
 	suite.Require().Error(err)
 	suite.Require().Nil(res)
 }
@@ -284,10 +278,9 @@ func (suite *KeeperTestSuite) TestCSRByContract() {
 		suite.Run(tc.name, func() {
 			suite.SetupTest()
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.prepare()
 
-			response, err := suite.queryClient.CSRByContract(ctx, request)
+			response, err := suite.queryClient.CSRByContract(suite.ctx, request)
 			if tc.pass {
 				suite.Require().NoError(err)
 			} else {
@@ -300,11 +293,10 @@ func (suite *KeeperTestSuite) TestCSRByContract() {
 
 // Test the query service for params
 func (suite *KeeperTestSuite) TestQueryParams() {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	expectedParams := types.DefaultParams()
 	expectedParams.EnableCsr = true
 
-	res, err := suite.queryClient.Params(ctx, &types.QueryParamsRequest{})
+	res, err := suite.queryClient.Params(suite.ctx, &types.QueryParamsRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expectedParams, res.Params)
 }
@@ -312,12 +304,11 @@ func (suite *KeeperTestSuite) TestQueryParams() {
 // Test the query service that retrieves the turnstile address
 func (suite *KeeperTestSuite) TestQueryTurnstile() {
 	suite.Commit()
-	ctx := sdk.WrapSDKContext(suite.ctx)
 
 	address, found := suite.app.CSRKeeper.GetTurnstile(suite.ctx)
 	suite.Require().True(found)
 
-	res, err := suite.queryClient.Turnstile(ctx, &types.QueryTurnstileRequest{})
+	res, err := suite.queryClient.Turnstile(suite.ctx, &types.QueryTurnstileRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(address.String(), res.Address)
 }

--- a/x/epochs/keeper/grpc_query_test.go
+++ b/x/epochs/keeper/grpc_query_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Canto-Network/Canto/v7/x/epochs/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 )
 
@@ -182,10 +181,9 @@ func (suite *KeeperTestSuite) TestCurrentEpoch() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.CurrentEpoch(ctx, req)
+			res, err := suite.queryClient.CurrentEpoch(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes, res)

--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -5,8 +5,8 @@ import (
 	"math/big"
 
 	errorsmod "cosmossdk.io/errors"
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -183,7 +183,7 @@ func (k Keeper) CallEVMWithData(
 			return nil, errorsmod.Wrapf(sdkerrors.ErrJSONMarshal, "failed to marshal tx args: %s", err.Error())
 		}
 
-		gasRes, err := k.evmKeeper.EstimateGas(sdk.WrapSDKContext(ctx), &evmtypes.EthCallRequest{
+		gasRes, err := k.evmKeeper.EstimateGas(ctx, &evmtypes.EthCallRequest{
 			Args:   args,
 			GasCap: config.DefaultGasCap,
 		})

--- a/x/erc20/keeper/evm_hooks_test.go
+++ b/x/erc20/keeper/evm_hooks_test.go
@@ -210,8 +210,7 @@ func (suite *KeeperTestSuite) TestEvmHooksRegisteredCoin() {
 				sender,
 			)
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
-			_, err := suite.app.Erc20Keeper.ConvertCoin(ctx, convertCoin)
+			_, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, convertCoin)
 			suite.Require().NoError(err, tc.name)
 			suite.Commit()
 

--- a/x/erc20/keeper/grpc_query_test.go
+++ b/x/erc20/keeper/grpc_query_test.go
@@ -3,7 +3,6 @@ package keeper_test
 import (
 	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/evmos/ethermint/tests"
 
@@ -66,10 +65,9 @@ func (suite *KeeperTestSuite) TestTokenPairs() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.TokenPairs(ctx, req)
+			res, err := suite.queryClient.TokenPairs(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes.Pagination, res.Pagination)
@@ -146,10 +144,9 @@ func (suite *KeeperTestSuite) TestTokenPair() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.TokenPair(ctx, req)
+			res, err := suite.queryClient.TokenPair(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes, res)
@@ -161,10 +158,9 @@ func (suite *KeeperTestSuite) TestTokenPair() {
 }
 
 func (suite *KeeperTestSuite) TestQueryParams() {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	expParams := types.DefaultParams()
 
-	res, err := suite.queryClient.Params(ctx, &types.QueryParamsRequest{})
+	res, err := suite.queryClient.Params(suite.ctx, &types.QueryParamsRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expParams, res.Params)
 }

--- a/x/erc20/keeper/keeper_test.go
+++ b/x/erc20/keeper/keeper_test.go
@@ -208,7 +208,6 @@ func (suite *KeeperTestSuite) MintFeeCollector(coins sdk.Coins) {
 
 // DeployContract deploys the ERC20MinterBurnerDecimalsContract.
 func (suite *KeeperTestSuite) DeployContract(name, symbol string, decimals uint8) (common.Address, error) {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 
 	ctorArgs, err := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack("", name, symbol, decimals)
@@ -225,7 +224,7 @@ func (suite *KeeperTestSuite) DeployContract(name, symbol string, decimals uint8
 		return common.Address{}, err
 	}
 
-	res, err := suite.queryClientEvm.EstimateGas(ctx, &evm.EthCallRequest{
+	res, err := suite.queryClientEvm.EstimateGas(suite.ctx, &evm.EthCallRequest{
 		Args:   args,
 		GasCap: uint64(config.DefaultGasCap),
 	})
@@ -253,7 +252,7 @@ func (suite *KeeperTestSuite) DeployContract(name, symbol string, decimals uint8
 		return common.Address{}, err
 	}
 
-	rsp, err := suite.app.EvmKeeper.EthereumTx(ctx, erc20DeployTx)
+	rsp, err := suite.app.EvmKeeper.EthereumTx(suite.ctx, erc20DeployTx)
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -263,7 +262,6 @@ func (suite *KeeperTestSuite) DeployContract(name, symbol string, decimals uint8
 }
 
 func (suite *KeeperTestSuite) DeployContractMaliciousDelayed(name string, symbol string) common.Address {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 
 	ctorArgs, err := contracts.ERC20MaliciousDelayedContract.ABI.Pack("", big.NewInt(1000000000000000000))
@@ -276,7 +274,7 @@ func (suite *KeeperTestSuite) DeployContractMaliciousDelayed(name string, symbol
 	})
 	suite.Require().NoError(err)
 
-	res, err := suite.queryClientEvm.EstimateGas(ctx, &evm.EthCallRequest{
+	res, err := suite.queryClientEvm.EstimateGas(suite.ctx, &evm.EthCallRequest{
 		Args:   args,
 		GasCap: uint64(config.DefaultGasCap),
 	})
@@ -299,14 +297,13 @@ func (suite *KeeperTestSuite) DeployContractMaliciousDelayed(name string, symbol
 	erc20DeployTx.From = suite.address.Hex()
 	err = erc20DeployTx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.signer)
 	suite.Require().NoError(err)
-	rsp, err := suite.app.EvmKeeper.EthereumTx(ctx, erc20DeployTx)
+	rsp, err := suite.app.EvmKeeper.EthereumTx(suite.ctx, erc20DeployTx)
 	suite.Require().NoError(err)
 	suite.Require().Empty(rsp.VmError)
 	return crypto.CreateAddress(suite.address, nonce)
 }
 
 func (suite *KeeperTestSuite) DeployContractDirectBalanceManipulation(name string, symbol string) common.Address {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 
 	ctorArgs, err := contracts.ERC20DirectBalanceManipulationContract.ABI.Pack("", big.NewInt(1000000000000000000))
@@ -319,7 +316,7 @@ func (suite *KeeperTestSuite) DeployContractDirectBalanceManipulation(name strin
 	})
 	suite.Require().NoError(err)
 
-	res, err := suite.queryClientEvm.EstimateGas(ctx, &evm.EthCallRequest{
+	res, err := suite.queryClientEvm.EstimateGas(suite.ctx, &evm.EthCallRequest{
 		Args:   args,
 		GasCap: uint64(config.DefaultGasCap),
 	})
@@ -342,7 +339,7 @@ func (suite *KeeperTestSuite) DeployContractDirectBalanceManipulation(name strin
 	erc20DeployTx.From = suite.address.Hex()
 	err = erc20DeployTx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.signer)
 	suite.Require().NoError(err)
-	rsp, err := suite.app.EvmKeeper.EthereumTx(ctx, erc20DeployTx)
+	rsp, err := suite.app.EvmKeeper.EthereumTx(suite.ctx, erc20DeployTx)
 	suite.Require().NoError(err)
 	suite.Require().Empty(rsp.VmError)
 	return crypto.CreateAddress(suite.address, nonce)
@@ -402,12 +399,11 @@ func (suite *KeeperTestSuite) GrantERC20Token(contractAddr, from, to common.Addr
 }
 
 func (suite *KeeperTestSuite) sendTx(contractAddr, from common.Address, transferData []byte) *evm.MsgEthereumTx {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 
 	args, err := json.Marshal(&evm.TransactionArgs{To: &contractAddr, From: &from, Data: (*hexutil.Bytes)(&transferData)})
 	suite.Require().NoError(err)
-	res, err := suite.queryClientEvm.EstimateGas(ctx, &evm.EthCallRequest{
+	res, err := suite.queryClientEvm.EstimateGas(suite.ctx, &evm.EthCallRequest{
 		Args:   args,
 		GasCap: uint64(config.DefaultGasCap),
 	})
@@ -434,7 +430,7 @@ func (suite *KeeperTestSuite) sendTx(contractAddr, from common.Address, transfer
 	ercTransferTx.From = suite.address.Hex()
 	err = ercTransferTx.Sign(ethtypes.LatestSignerForChainID(chainID), suite.signer)
 	suite.Require().NoError(err)
-	rsp, err := suite.app.EvmKeeper.EthereumTx(ctx, ercTransferTx)
+	rsp, err := suite.app.EvmKeeper.EthereumTx(suite.ctx, ercTransferTx)
 	suite.Require().NoError(err)
 	suite.Require().Empty(rsp.VmError)
 	return ercTransferTx

--- a/x/erc20/keeper/msg_server_test.go
+++ b/x/erc20/keeper/msg_server_test.go
@@ -340,7 +340,6 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeCoin() {
 			tc.malleate(erc20)
 			suite.Commit()
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			coins := sdk.NewCoins(sdk.NewCoin(cosmosTokenBase, sdkmath.NewInt(tc.mint)))
 			sender := sdk.AccAddress(suite.address.Bytes())
 			msg := types.NewMsgConvertCoin(
@@ -353,7 +352,7 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeCoin() {
 			suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, types.ModuleName, sender, coins)
 
 			tc.extra()
-			res, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			res, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 			expRes := &types.MsgConvertCoinResponse{}
 			suite.Commit()
 			balance := suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
@@ -518,8 +517,7 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeCoin() {
 				sender,
 			)
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
-			_, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			_, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 			suite.Require().NoError(err, tc.name)
 			suite.Commit()
 			balance := suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
@@ -528,7 +526,6 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeCoin() {
 			suite.Require().Equal(balance, big.NewInt(tc.burn))
 
 			// Convert ERC20s back to Coins
-			ctx = sdk.WrapSDKContext(suite.ctx)
 			contractAddr := common.HexToAddress(pair.Erc20Address)
 			msgConvertERC20 := types.NewMsgConvertERC20(
 				sdkmath.NewInt(tc.reconvert),
@@ -538,7 +535,7 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeCoin() {
 			)
 
 			tc.malleate()
-			res, err := suite.app.Erc20Keeper.ConvertERC20(ctx, msgConvertERC20)
+			res, err := suite.app.Erc20Keeper.ConvertERC20(suite.ctx, msgConvertERC20)
 			expRes := &types.MsgConvertERC20Response{}
 			suite.Commit()
 			balance = suite.BalanceOf(contractAddr, suite.address)
@@ -1076,7 +1073,6 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeERC20() {
 
 			// Convert Coins back to ERC20s
 			receiver := suite.address
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			msg := types.NewMsgConvertCoin(
 				sdk.NewCoin(coinName, sdkmath.NewInt(tc.convert)),
 				receiver,
@@ -1084,7 +1080,7 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeERC20() {
 			)
 
 			tc.extra()
-			res, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			res, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 
 			expRes := &types.MsgConvertCoinResponse{}
 			suite.Commit()
@@ -1135,12 +1131,10 @@ func (suite *KeeperTestSuite) TestWrongPairOwnerERC20NativeCoin() {
 			pair.ContractOwner = types.OWNER_UNSPECIFIED
 			suite.app.Erc20Keeper.SetTokenPair(suite.ctx, *pair)
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
-			_, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			_, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 			suite.Require().Error(err, tc.name)
 
 			// Convert ERC20s back to Coins
-			ctx = sdk.WrapSDKContext(suite.ctx)
 			contractAddr := common.HexToAddress(pair.Erc20Address)
 			msgConvertERC20 := types.NewMsgConvertERC20(
 				sdkmath.NewInt(tc.reconvert),
@@ -1149,7 +1143,7 @@ func (suite *KeeperTestSuite) TestWrongPairOwnerERC20NativeCoin() {
 				suite.address,
 			)
 
-			_, err = suite.app.Erc20Keeper.ConvertERC20(ctx, msgConvertERC20)
+			_, err = suite.app.Erc20Keeper.ConvertERC20(suite.ctx, msgConvertERC20)
 			suite.Require().Error(err, tc.name)
 		})
 	}
@@ -1290,7 +1284,6 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeIBCVoucher() {
 			tc.malleate(erc20)
 			suite.Commit()
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			coins := sdk.NewCoins(sdk.NewCoin(ibcBase, sdkmath.NewInt(tc.mint)))
 			sender := sdk.AccAddress(suite.address.Bytes())
 			msg := types.NewMsgConvertCoin(
@@ -1303,7 +1296,7 @@ func (suite *KeeperTestSuite) TestConvertCoinNativeIBCVoucher() {
 			suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, types.ModuleName, sender, coins)
 
 			tc.extra()
-			res, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			res, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 			expRes := &types.MsgConvertCoinResponse{}
 			suite.Commit()
 			balance := suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
@@ -1468,8 +1461,7 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeIBCVoucher() {
 				sender,
 			)
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
-			_, err := suite.app.Erc20Keeper.ConvertCoin(ctx, msg)
+			_, err := suite.app.Erc20Keeper.ConvertCoin(suite.ctx, msg)
 			suite.Require().NoError(err, tc.name)
 			suite.Commit()
 			balance := suite.BalanceOf(common.HexToAddress(pair.Erc20Address), suite.address)
@@ -1478,7 +1470,6 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeIBCVoucher() {
 			suite.Require().Equal(balance, big.NewInt(tc.burn))
 
 			// Convert ERC20s back to Coins
-			ctx = sdk.WrapSDKContext(suite.ctx)
 			contractAddr := common.HexToAddress(pair.Erc20Address)
 			msgConvertERC20 := types.NewMsgConvertERC20(
 				sdkmath.NewInt(tc.reconvert),
@@ -1488,7 +1479,7 @@ func (suite *KeeperTestSuite) TestConvertERC20NativeIBCVoucher() {
 			)
 
 			tc.malleate()
-			res, err := suite.app.Erc20Keeper.ConvertERC20(ctx, msgConvertERC20)
+			res, err := suite.app.Erc20Keeper.ConvertERC20(suite.ctx, msgConvertERC20)
 			expRes := &types.MsgConvertERC20Response{}
 			suite.Commit()
 			balance = suite.BalanceOf(contractAddr, suite.address)

--- a/x/govshuttle/keeper/keeper_test.go
+++ b/x/govshuttle/keeper/keeper_test.go
@@ -60,7 +60,6 @@ func (suite *KeeperTestSuite) SetupTest() {
 }
 
 func (suite *KeeperTestSuite) DeployCaller() (common.Address, error) {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	chainID := suite.app.EvmKeeper.ChainID()
 
 	ctorArgs, err := contracts.CallerContract.ABI.Pack("")
@@ -79,7 +78,7 @@ func (suite *KeeperTestSuite) DeployCaller() (common.Address, error) {
 		return common.Address{}, err
 	}
 
-	res, err := suite.queryClientEvm.EstimateGas(ctx, &evm.EthCallRequest{
+	res, err := suite.queryClientEvm.EstimateGas(suite.ctx, &evm.EthCallRequest{
 		Args:   args,
 		GasCap: uint64(config.DefaultGasCap),
 	})
@@ -107,7 +106,7 @@ func (suite *KeeperTestSuite) DeployCaller() (common.Address, error) {
 		return common.Address{}, err
 	}
 
-	rsp, err := suite.app.EvmKeeper.EthereumTx(ctx, erc20DeployTx)
+	rsp, err := suite.app.EvmKeeper.EthereumTx(suite.ctx, erc20DeployTx)
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/x/inflation/keeper/grpc_query_test.go
+++ b/x/inflation/keeper/grpc_query_test.go
@@ -46,10 +46,9 @@ func (suite *KeeperTestSuite) TestPeriod() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.Period(ctx, req)
+			res, err := suite.queryClient.Period(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes, res)
@@ -105,10 +104,9 @@ func (suite *KeeperTestSuite) TestEpochMintProvision() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.EpochMintProvision(ctx, req)
+			res, err := suite.queryClient.EpochMintProvision(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes, res)
@@ -155,10 +153,9 @@ func (suite *KeeperTestSuite) TestSkippedEpochs() {
 		suite.Run(fmt.Sprintf("Case %s", tc.name), func() {
 			suite.SetupTest() // reset
 
-			ctx := sdk.WrapSDKContext(suite.ctx)
 			tc.malleate()
 
-			res, err := suite.queryClient.SkippedEpochs(ctx, req)
+			res, err := suite.queryClient.SkippedEpochs(suite.ctx, req)
 			if tc.expPass {
 				suite.Require().NoError(err)
 				suite.Require().Equal(expRes, res)
@@ -171,7 +168,6 @@ func (suite *KeeperTestSuite) TestSkippedEpochs() {
 
 func (suite *KeeperTestSuite) TestQueryCirculatingSupply() {
 	// Team allocation is only set on mainnet
-	ctx := sdk.WrapSDKContext(suite.ctx)
 
 	// Mint coins to increase supply
 	mintDenom := suite.app.InflationKeeper.GetParams(suite.ctx).MintDenom
@@ -182,13 +178,12 @@ func (suite *KeeperTestSuite) TestQueryCirculatingSupply() {
 	// team allocation is zero if not on mainnet
 	expCirculatingSupply := sdk.NewDecCoin(mintDenom, sdk.TokensFromConsensusPower(400_000_000, ethermint.PowerReduction))
 
-	res, err := suite.queryClient.CirculatingSupply(ctx, &types.QueryCirculatingSupplyRequest{})
+	res, err := suite.queryClient.CirculatingSupply(suite.ctx, &types.QueryCirculatingSupplyRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expCirculatingSupply, res.CirculatingSupply)
 }
 
 func (suite *KeeperTestSuite) TestQueryInflationRate() {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 
 	// Mint coins to increase supply
 	mintDenom := suite.app.InflationKeeper.GetParams(suite.ctx).MintDenom
@@ -197,16 +192,15 @@ func (suite *KeeperTestSuite) TestQueryInflationRate() {
 	suite.Require().NoError(err)
 
 	expInflationRate := sdkmath.LegacyMustNewDecFromStr("4.076087000000000000")
-	res, err := suite.queryClient.InflationRate(ctx, &types.QueryInflationRateRequest{})
+	res, err := suite.queryClient.InflationRate(suite.ctx, &types.QueryInflationRateRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expInflationRate, res.InflationRate)
 }
 
 func (suite *KeeperTestSuite) TestQueryParams() {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	expParams := types.DefaultParams()
 
-	res, err := suite.queryClient.Params(ctx, &types.QueryParamsRequest{})
+	res, err := suite.queryClient.Params(suite.ctx, &types.QueryParamsRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expParams, res.Params)
 }

--- a/x/onboarding/keeper/grpc_query_test.go
+++ b/x/onboarding/keeper/grpc_query_test.go
@@ -1,16 +1,13 @@
 package keeper_test
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/Canto-Network/Canto/v7/x/onboarding/types"
 )
 
 func (suite *KeeperTestSuite) TestQueryParams() {
-	ctx := sdk.WrapSDKContext(suite.ctx)
 	expParams := types.DefaultParams()
 
-	res, err := suite.queryClient.Params(ctx, &types.QueryParamsRequest{})
+	res, err := suite.queryClient.Params(suite.ctx, &types.QueryParamsRequest{})
 	suite.Require().NoError(err)
 	suite.Require().Equal(expParams, res.Params)
 }

--- a/x/onboarding/keeper/ibc_callbacks.go
+++ b/x/onboarding/keeper/ibc_callbacks.go
@@ -134,7 +134,7 @@ func (k Keeper) OnRecvPacket(
 	// the ICS20 packet data
 
 	// Use MsgConvertCoin to convert the Cosmos Coin to an ERC20
-	if _, err = k.erc20Keeper.ConvertCoin(sdk.WrapSDKContext(ctx), convertMsg); err != nil {
+	if _, err = k.erc20Keeper.ConvertCoin(ctx, convertMsg); err != nil {
 		logger.Error("failed to convert coins", "error", err)
 		return ack
 	}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
The sdk.WrapSDKContext function is deprecated and has been removed from the codebase. This change refactors the affected code to use the recommended alternatives, ensuring compatibility with future SDK versions and maintaining code quality.

Closes: [[L-1]](https://github.com/code-423n4/2024-05-canto-findings/issues/33)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
