### PR TITLE
refactor: Remove redundant EventTypeMessage emission in custom modules

### DIFF
--- a/x/coinswap/keeper/keeper_test.go
+++ b/x/coinswap/keeper/keeper_test.go
@@ -93,6 +93,7 @@ func (suite *TestSuite) SetupTest() {
 
 	suite.keeper = suite.app.CoinswapKeeper
 	suite.queryClient = queryClient
+	suite.msgServer = keeper.NewMsgServerImpl(suite.keeper)
 
 	sdk.SetCoinDenomRegex(func() string {
 		return `[a-zA-Z][a-zA-Z0-9/\-]{2,127}`

--- a/x/coinswap/keeper/msg_server.go
+++ b/x/coinswap/keeper/msg_server.go
@@ -92,14 +92,6 @@ func (m msgServer) RemoveLiquidity(goCtx context.Context, msg *types.MsgRemoveLi
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-	)
-
 	var coins = make([]*sdk.Coin, 0, withdrawCoins.Len())
 	for _, coin := range withdrawCoins {
 		coins = append(coins, &coin)
@@ -141,13 +133,6 @@ func (m msgServer) SwapCoin(goCtx context.Context, msg *types.MsgSwapOrder) (*ty
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Input.Address),
-		),
-	)
 	return &types.MsgSwapCoinResponse{}, nil
 }
 

--- a/x/coinswap/keeper/msg_server.go
+++ b/x/coinswap/keeper/msg_server.go
@@ -56,14 +56,6 @@ func (m msgServer) AddLiquidity(goCtx context.Context, msg *types.MsgAddLiquidit
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			sdk.EventTypeMessage,
-			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
-			sdk.NewAttribute(sdk.AttributeKeySender, msg.Sender),
-		),
-	)
-
 	return &types.MsgAddLiquidityResponse{
 		MintToken: &mintToken,
 	}, nil


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
EventTypeMessage events with sdk.AttributeKeyModule and sdk.AttributeKeySender are now emitted directly at message execution (in baseapp). This change removes the redundant boilerplate event emission from all custom modules.

The module name is assumed by baseapp to be the second element of the message route, e.g., "cosmos.bank.v1beta1.MsgSend" -> "bank". For modules that do not follow the standard message path (e.g., IBC), it is advised to continue emitting the module name event. Baseapp only emits the EventTypeMessage event if the module has not already done so.

This refactor ensures cleaner code and leverages the automatic event emission provided by baseapp.

Closes: [L-4](https://github.com/code-423n4/2024-05-canto-findings/issues/33)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
