### PR TITLE
refactor: `CustomGetSigners` for `MsgSwapOrder`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -312,7 +312,13 @@ func NewCanto(
 		},
 	}
 
-	DefineCustomGetSigners(&signingOptions)
+	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
+	signingOptions.DefineCustomGetSigners(
+		protov2.MessageName(&coinswapv1.MsgSwapOrder{}),
+		coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(&signingOptions),
+	)
 
 	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles:     proto.HybridResolver,
@@ -995,17 +1001,6 @@ func NewCanto(
 	}()
 
 	return app
-}
-
-func DefineCustomGetSigners(options *signing.Options) {
-	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
-	options.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
-	options.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
-	options.DefineCustomGetSigners(
-		protov2.MessageName(&coinswapv1.MsgSwapOrder{}),
-		coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(options),
-	)
-
 }
 
 // use Canto's custom AnteHandler

--- a/app/app.go
+++ b/app/app.go
@@ -312,10 +312,7 @@ func NewCanto(
 		},
 	}
 
-	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2)
+	DefineCustomGetSigners(options * signing.Options)
 
 	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles:     proto.HybridResolver,
@@ -998,6 +995,14 @@ func NewCanto(
 	}()
 
 	return app
+}
+
+func DefineCustomGetSigners(options *signing.Options) {
+	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
+	options.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
+	options.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
+	options.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2(options))
+
 }
 
 // use Canto's custom AnteHandler

--- a/app/app.go
+++ b/app/app.go
@@ -312,7 +312,7 @@ func NewCanto(
 		},
 	}
 
-	// evm/MsgEthereumTx, erc20/MsgConvertERC20
+	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2)

--- a/app/app.go
+++ b/app/app.go
@@ -121,6 +121,7 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v8/testing"
 	ibctestingtypes "github.com/cosmos/ibc-go/v8/testing/types"
 
+	coinswapv1 "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
 	erc20v1 "github.com/Canto-Network/Canto/v7/api/canto/erc20/v1"
 	evmv1 "github.com/evmos/ethermint/api/ethermint/evm/v1"
 	ethante "github.com/evmos/ethermint/app/ante"
@@ -314,6 +315,7 @@ func NewCanto(
 	// evm/MsgEthereumTx, erc20/MsgConvertERC20
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2)
 
 	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles:     proto.HybridResolver,

--- a/app/app.go
+++ b/app/app.go
@@ -312,7 +312,7 @@ func NewCanto(
 		},
 	}
 
-	DefineCustomGetSigners(options * signing.Options)
+	DefineCustomGetSigners(&signingOptions)
 
 	interfaceRegistry, _ := types.NewInterfaceRegistryWithOptions(types.InterfaceRegistryOptions{
 		ProtoFiles:     proto.HybridResolver,
@@ -1001,7 +1001,10 @@ func DefineCustomGetSigners(options *signing.Options) {
 	// evm/MsgEthereumTx, erc20/MsgConvertERC20, coinswap/MsgSwapOrder
 	options.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
 	options.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
-	options.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2(options))
+	options.DefineCustomGetSigners(
+		protov2.MessageName(&coinswapv1.MsgSwapOrder{}),
+		coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(options),
+	)
 
 }
 

--- a/app/signer_test.go
+++ b/app/signer_test.go
@@ -3,17 +3,21 @@ package app
 import (
 	"testing"
 
-	"cosmossdk.io/x/tx/signing"
-	coinswapapi "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
-	coinswaptypes "github.com/Canto-Network/Canto/v7/x/coinswap/types"
-	"github.com/cosmos/cosmos-sdk/codec/address"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	protov2 "google.golang.org/protobuf/proto"
+
+	"cosmossdk.io/x/tx/signing"
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	coinswapv1 "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
+	erc20v1 "github.com/Canto-Network/Canto/v7/api/canto/erc20/v1"
+	coinswaptypes "github.com/Canto-Network/Canto/v7/x/coinswap/types"
+	erc20types "github.com/Canto-Network/Canto/v7/x/erc20/types"
 )
 
-func TestMsgSwapOrderSigners(t *testing.T) {
-
+func TestDefineCustomGetSigners(t *testing.T) {
 	addr := "canto13e9t6s6ra8caz5zzmy5w9v23dm2dr5nrr9sz03"
 	accAddr, err := sdk.AccAddressFromBech32(addr)
 	require.NoError(t, err)
@@ -26,7 +30,8 @@ func TestMsgSwapOrderSigners(t *testing.T) {
 			Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
 		},
 	}
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapapi.MsgSwapOrder{}), coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(&signingOptions))
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapv1.MsgSwapOrder{}), coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(&signingOptions))
 
 	ctx, err := signing.NewContext(signingOptions)
 	require.NoError(t, err)
@@ -38,11 +43,18 @@ func TestMsgSwapOrderSigners(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "MsgSwapOrder",
-			msg: &coinswapapi.MsgSwapOrder{
-				Input: &coinswapapi.Input{Address: addr},
+			name: "MsgConvertERC20",
+			msg: &erc20v1.MsgConvertERC20{
+				Sender: common.BytesToAddress(accAddr.Bytes()).String(),
 			},
-			want: [][]byte{accAddr},
+			want: [][]byte{accAddr.Bytes()},
+		},
+		{
+			name: "MsgSwapOrder",
+			msg: &coinswapv1.MsgSwapOrder{
+				Input: &coinswapv1.Input{Address: addr},
+			},
+			want: [][]byte{accAddr.Bytes()},
 		},
 	}
 	for _, test := range tests {

--- a/app/signer_test.go
+++ b/app/signer_test.go
@@ -5,13 +5,9 @@ import (
 
 	"cosmossdk.io/x/tx/signing"
 	coinswapapi "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
-	erc20v1 "github.com/Canto-Network/Canto/v7/api/canto/erc20/v1"
 	coinswaptypes "github.com/Canto-Network/Canto/v7/x/coinswap/types"
-	erc20types "github.com/Canto-Network/Canto/v7/x/erc20/types"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	evmv1 "github.com/evmos/ethermint/api/ethermint/evm/v1"
-	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/stretchr/testify/require"
 	protov2 "google.golang.org/protobuf/proto"
 )
@@ -19,6 +15,8 @@ import (
 func TestMsgSwapOrderSigners(t *testing.T) {
 
 	addr := "canto13e9t6s6ra8caz5zzmy5w9v23dm2dr5nrr9sz03"
+	accAddr, err := sdk.AccAddressFromBech32(addr)
+	require.NoError(t, err)
 
 	signingOptions := signing.Options{
 		AddressCodec: address.Bech32Codec{
@@ -29,8 +27,6 @@ func TestMsgSwapOrderSigners(t *testing.T) {
 		},
 	}
 	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapapi.MsgSwapOrder{}), coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(&signingOptions))
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
 
 	ctx, err := signing.NewContext(signingOptions)
 	require.NoError(t, err)
@@ -46,7 +42,7 @@ func TestMsgSwapOrderSigners(t *testing.T) {
 			msg: &coinswapapi.MsgSwapOrder{
 				Input: &coinswapapi.Input{Address: addr},
 			},
-			want: [][]byte{[]byte(sdk.AccAddress(addr))},
+			want: [][]byte{accAddr},
 		},
 	}
 	for _, test := range tests {

--- a/app/signer_test.go
+++ b/app/signer_test.go
@@ -5,18 +5,20 @@ import (
 
 	"cosmossdk.io/x/tx/signing"
 	coinswapapi "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
+	erc20v1 "github.com/Canto-Network/Canto/v7/api/canto/erc20/v1"
 	coinswaptypes "github.com/Canto-Network/Canto/v7/x/coinswap/types"
+	erc20types "github.com/Canto-Network/Canto/v7/x/erc20/types"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	evmv1 "github.com/evmos/ethermint/api/ethermint/evm/v1"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
 	"github.com/stretchr/testify/require"
 	protov2 "google.golang.org/protobuf/proto"
 )
 
 func TestMsgSwapOrderSigners(t *testing.T) {
-	sw := coinswapapi.MsgSwapOrder{
-		Input: &coinswapapi.Input{Address: "signer"},
-	}
+
+	addr := "canto13e9t6s6ra8caz5zzmy5w9v23dm2dr5nrr9sz03"
 
 	signingOptions := signing.Options{
 		AddressCodec: address.Bech32Codec{
@@ -26,14 +28,36 @@ func TestMsgSwapOrderSigners(t *testing.T) {
 			Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
 		},
 	}
-	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapapi.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2)
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapapi.MsgSwapOrder{}), coinswaptypes.CreateGetSignersFromMsgSwapOrderV2(&signingOptions))
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&evmv1.MsgEthereumTx{}), evmtypes.GetSignersFromMsgEthereumTxV2)
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&erc20v1.MsgConvertERC20{}), erc20types.GetSignersFromMsgConvertERC20V2)
 
 	ctx, err := signing.NewContext(signingOptions)
-
 	require.NoError(t, err)
-	signers, err := ctx.GetSigners(&sw)
 
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(signers))
-	assert.Equal(t, []byte("signer"), signers[0])
+	tests := []struct {
+		name    string
+		msg     protov2.Message
+		want    [][]byte
+		wantErr bool
+	}{
+		{
+			name: "MsgSwapOrder",
+			msg: &coinswapapi.MsgSwapOrder{
+				Input: &coinswapapi.Input{Address: addr},
+			},
+			want: [][]byte{[]byte(sdk.AccAddress(addr))},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			signers, err := ctx.GetSigners(test.msg)
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.want, signers)
+		})
+	}
 }

--- a/app/signer_test.go
+++ b/app/signer_test.go
@@ -1,0 +1,39 @@
+package app
+
+import (
+	"testing"
+
+	"cosmossdk.io/x/tx/signing"
+	coinswapapi "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
+	coinswaptypes "github.com/Canto-Network/Canto/v7/x/coinswap/types"
+	"github.com/cosmos/cosmos-sdk/codec/address"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
+)
+
+func TestMsgSwapOrderSigners(t *testing.T) {
+	sw := coinswapapi.MsgSwapOrder{
+		Input: &coinswapapi.Input{Address: "signer"},
+	}
+
+	signingOptions := signing.Options{
+		AddressCodec: address.Bech32Codec{
+			Bech32Prefix: sdk.GetConfig().GetBech32AccountAddrPrefix(),
+		},
+		ValidatorAddressCodec: address.Bech32Codec{
+			Bech32Prefix: sdk.GetConfig().GetBech32ValidatorAddrPrefix(),
+		},
+	}
+	signingOptions.DefineCustomGetSigners(protov2.MessageName(&coinswapapi.MsgSwapOrder{}), coinswaptypes.GetSignersFromMsgSwapOrderV2)
+
+	ctx, err := signing.NewContext(signingOptions)
+
+	require.NoError(t, err)
+	signers, err := ctx.GetSigners(&sw)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(signers))
+	assert.Equal(t, []byte("signer"), signers[0])
+}

--- a/x/coinswap/types/msgs.go
+++ b/x/coinswap/types/msgs.go
@@ -78,16 +78,18 @@ func NewMsgRemoveLiquidity(
 	}
 }
 
-func GetSignersFromMsgSwapOrderV2(options *signing.Options, msg protov2.Message) ([][]byte, error) {
-	msgv2, ok := msg.(*coinswapv1.MsgSwapOrder)
-	if !ok {
-		return nil, fmt.Errorf("invalid x/coinswap/MsgSwapOrder msg v2: %v", msg)
-	}
+func CreateGetSignersFromMsgSwapOrderV2(options *signing.Options) func(msg protov2.Message) ([][]byte, error) {
+	return func(msg protov2.Message) ([][]byte, error) {
+		msgv2, ok := msg.(*coinswapv1.MsgSwapOrder)
+		if !ok {
+			return nil, fmt.Errorf("invalid x/coinswap/MsgSwapOrder msg v2: %v", msg)
+		}
 
-	addr, err := options.AddressCodec.StringToBytes(msgv2.Input.Address)
-	if err != nil {
-		return nil, err
-	}
+		addr, err := options.AddressCodec.StringToBytes(msgv2.Input.Address)
+		if err != nil {
+			return nil, err
+		}
 
-	return [][]byte{addr}, nil
+		return [][]byte{addr}, nil
+	}
 }

--- a/x/coinswap/types/msgs.go
+++ b/x/coinswap/types/msgs.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	sdkmath "cosmossdk.io/math"
+	coinswapv1 "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	protov2 "google.golang.org/protobuf/proto"
 )
 
 var (
@@ -71,4 +73,16 @@ func NewMsgRemoveLiquidity(
 		Deadline:          deadline,
 		Sender:            sender,
 	}
+}
+
+func GetSignersFromMsgSwapOrderV2(msg protov2.Message) ([][]byte, error) {
+	msgv2, ok := msg.(*coinswapv1.MsgSwapOrder)
+	if !ok {
+		return nil, nil
+	}
+
+	signers := [][]byte{}
+	signers = append(signers, []byte(msgv2.Input.Address))
+
+	return signers, nil
 }

--- a/x/coinswap/types/msgs.go
+++ b/x/coinswap/types/msgs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdkmath "cosmossdk.io/math"
+	"cosmossdk.io/x/tx/signing"
 	coinswapv1 "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	protov2 "google.golang.org/protobuf/proto"
@@ -77,14 +78,16 @@ func NewMsgRemoveLiquidity(
 	}
 }
 
-func GetSignersFromMsgSwapOrderV2(msg protov2.Message) ([][]byte, error) {
+func GetSignersFromMsgSwapOrderV2(options *signing.Options, msg protov2.Message) ([][]byte, error) {
 	msgv2, ok := msg.(*coinswapv1.MsgSwapOrder)
 	if !ok {
 		return nil, fmt.Errorf("invalid x/coinswap/MsgSwapOrder msg v2: %v", msg)
 	}
 
-	signers := [][]byte{}
-	signers = append(signers, []byte(msgv2.Input.Address))
+	addr, err := options.AddressCodec.StringToBytes(msgv2.Input.Address)
+	if err != nil {
+		return nil, err
+	}
 
-	return signers, nil
+	return [][]byte{addr}, nil
 }

--- a/x/coinswap/types/msgs.go
+++ b/x/coinswap/types/msgs.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	sdkmath "cosmossdk.io/math"
 	coinswapv1 "github.com/Canto-Network/Canto/v7/api/canto/coinswap/v1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -78,7 +80,7 @@ func NewMsgRemoveLiquidity(
 func GetSignersFromMsgSwapOrderV2(msg protov2.Message) ([][]byte, error) {
 	msgv2, ok := msg.(*coinswapv1.MsgSwapOrder)
 	if !ok {
-		return nil, nil
+		return nil, fmt.Errorf("invalid x/coinswap/MsgSwapOrder msg v2: %v", msg)
 	}
 
 	signers := [][]byte{}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
[Cosmos SDK v0.50 this method has been dropped](https://github.com/cosmos/cosmos-sdk/blob/release/v0.50.x/UPGRADING.md#all) and replaced with the declarative cosmos.msg.v1.signer protobuf tag.
For `MsgSwapOrder`, which does not have a cosmos.msg.v1.signer to
resolve the signer, custom GetSigners function is defined.

Closes: https://github.com/code-423n4/2024-05-canto-findings/issues/27

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] included the necessary unit and integration tests
- [x] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
