### PR TITLE
bug: Add legacy validate basic logic to govshuttle msgs

### DIFF
--- a/x/govshuttle/keeper/msg_server_test.go
+++ b/x/govshuttle/keeper/msg_server_test.go
@@ -87,6 +87,23 @@ func (suite *KeeperTestSuite) TestMsgExecutionByProposal() {
 			true,
 		},
 		{
+			"fail - MsgLendingMarketProposal - validate basic logic",
+			&govshuttletypes.MsgLendingMarketProposal{
+				Authority:   "canto1yrmjye0zyfvr0lthc6fwq7qlwg9e8muftxa630",
+				Title:       "lending market proposal test",
+				Description: "lending market proposal test description",
+				Metadata: &govshuttletypes.LendingMarketMetadata{
+					Account:    []string{"0x20F72265e2225837fd77C692e0781f720B93eF89", "0xf6Db2570A2417188a5788D6d5Fd9faAa5B1fE555"},
+					PropId:     1,
+					Values:     []uint64{1234},
+					Calldatas:  []string{hex.EncodeToString([]byte("calldata1")), hex.EncodeToString([]byte("calldata2"))},
+					Signatures: []string{"sig1", "sig2"},
+				},
+			},
+			func(uint64, sdk.Msg) {},
+			true,
+		},
+		{
 			"ok - MsgLendingMarketProposal",
 			&govshuttletypes.MsgLendingMarketProposal{
 				Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
@@ -158,6 +175,22 @@ func (suite *KeeperTestSuite) TestMsgExecutionByProposal() {
 			true,
 		},
 		{
+			"fail - MsgTreasuryProposal - validate basic logic",
+			&govshuttletypes.MsgTreasuryProposal{
+				Authority:   "canto1yrmjye0zyfvr0lthc6fwq7qlwg9e8muftxa630",
+				Title:       "treasury proposal test",
+				Description: "treasury proposal test description",
+				Metadata: &govshuttletypes.TreasuryProposalMetadata{
+					PropID:    2,
+					Recipient: "0x20F72265e2225837fd77C692e0781f720B93eF89",
+					Amount:    1234,
+					Denom:     "canto2",
+				},
+			},
+			func(uint64, sdk.Msg) {},
+			true,
+		},
+		{
 			"ok - MsgTreasuryProposal",
 			&govshuttletypes.MsgTreasuryProposal{
 				Authority:   authtypes.NewModuleAddress(govtypes.ModuleName).String(),
@@ -167,7 +200,7 @@ func (suite *KeeperTestSuite) TestMsgExecutionByProposal() {
 					PropID:    2,
 					Recipient: "0x20F72265e2225837fd77C692e0781f720B93eF89",
 					Amount:    1234,
-					Denom:     "acanto",
+					Denom:     "canto",
 				},
 			},
 			func(proposalId uint64, msg sdk.Msg) {


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

- Added validate basic logic that was missing. (ref. [original validate basic logics](https://github.com/Canto-Network/Canto/blob/972b7c6080fed051140128264e372d610966b621/x/govshuttle/types/proposal.go#L58-L90))

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [ ] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
