### PR TITLE
feat: Add cli pagination cmd to query "cantod q csr csrs"

### DIFF
--- a/x/csr/client/cli/query.go
+++ b/x/csr/client/cli/query.go
@@ -95,6 +95,7 @@ func CmdQueryCSRs() *cobra.Command {
 	}
 
 	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "csrs")
 
 	return cmd
 }


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description
- fixes an issue where the pagination flag was not present in the csrs query, making it impossible to query for all csrs.

### how to test
- pagination flag must be available in the csrs query
- eg. cantod query csr csrs --page 3, cantod query csr csrs --offset 333 --limit 99, ...

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] targeted the correct branch (see [PR Targeting](https://github.com/canto-network/canto/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] included the necessary unit and integration tests
- [ ] reviewed "Files changed" and left comments if necessary
 
### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
